### PR TITLE
refactor(fslib): early throw while populating stats

### DIFF
--- a/packages/yarnpkg-fslib/sources/ZipFS.ts
+++ b/packages/yarnpkg-fslib/sources/ZipFS.ts
@@ -124,11 +124,9 @@ export class ZipFS extends BasePortableFakeFS {
         try {
           this.stats = this.baseFs!.statSync(source);
         } catch (error) {
-          if (error.code === `ENOENT` && pathOptions.create) {
-            this.stats = statUtils.makeDefaultStats();
-          } else {
+          if (error.code !== `ENOENT` || !pathOptions.create)
             throw error;
-          }
+          this.stats = statUtils.makeDefaultStats();
         }
       } else {
         this.stats = statUtils.makeDefaultStats();


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
